### PR TITLE
Update bro-pkg.meta

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,3 +1,4 @@
 [package]
-version = 1.0.0
+description = Modified version of scan.bro to add destination IP sampling.
+tags = sumstats
 script_dir = scripts


### PR DESCRIPTION
In the near future, bro-pkg will expect to find all package metadata in bro-pkg.meta instead of having tags/description fields maintained separately in package source's bro-pkg.index.

The version field can be removed.  Instead, use git tags for versioning (optional).  More info on versioning here:

http://bro-package-manager.readthedocs.io/en/latest/package.html#package-versioning